### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/chriskacerguis/certy/security/code-scanning/1](https://github.com/chriskacerguis/certy/security/code-scanning/1)

To fix the problem, explicitly specify the minimal necessary permissions for the `test` job in the workflow YAML. Since the `test` job only checks out code and runs tests, it only requires read access to repository contents (`contents: read`). The fix is to add a `permissions:` block with `contents: read` in the `test` job configuration (underneath `runs-on: ubuntu-latest`), aligning it with the principle of least privilege.

You only need to add:

```yaml
permissions:
  contents: read
```

within the `test` job definition (e.g., between `runs-on: ubuntu-latest` and `steps:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
